### PR TITLE
Support whitespace in function decls

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -154,6 +154,21 @@ in_example {
     docblock = ""
 }
 
+/^# @name/ {
+    sub(/^# @name /, "")
+
+    name = $0
+
+    doc = doc "\n" render("h1", $name) "\n" docblock
+
+    url = $name
+    gsub(/\W/, "", url)
+
+    toc = toc "\n" "* [" $name "](#" url ")"
+
+    docblock = ""
+}
+
 END {
     print toc
     print ""

--- a/shdoc
+++ b/shdoc
@@ -141,7 +141,7 @@ in_example {
     docblock = docblock "\n\n" render("li", $0) "\n"
 }
 
-/^(function )?([a-zA-Z0-9_:-]+)(\(\))? \{/ && docblock != "" {
+/^(function([ \t])+)?([a-zA-Z0-9_:-]+)([ \t]*)(\(([ \t]*)\))?([ \t]*)\{/ && docblock != "" {
     sub(/^function /, "")
 
     doc = doc "\n" render("h1", $1) "\n" docblock

--- a/shdoc
+++ b/shdoc
@@ -5,6 +5,9 @@ BEGIN {
         style = "github"
     }
 
+    styles["github", "title", "from"] = ".*"
+    styles["github", "title", "to"] = "# &"
+
     styles["github", "h1", "from"] = ".*"
     styles["github", "h1", "to"] = "## &"
 
@@ -141,7 +144,7 @@ in_example {
     docblock = docblock "\n\n" render("li", $0) "\n"
 }
 
-/^(function([ \t])+)?([a-zA-Z0-9_:-]+)([ \t]*)(\(([ \t]*)\))?([ \t]*)\{/ && docblock != "" {
+/^(function\s+)?([a-zA-Z0-9_:-]+)(\s*)(\((\s*)\))?(\s*)\{/ && docblock != "" {
     sub(/^function /, "")
 
     doc = doc "\n" render("h1", $1) "\n" docblock


### PR DESCRIPTION
Addresses #4 

The current pattern doesn't allow for whitespace in function decls, this adds some basic support.