### PR TITLE
Spaces before function

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -141,7 +141,7 @@ in_example {
     docblock = docblock "\n\n" render("li", $0) "\n"
 }
 
-/^(function )?[[:space:]]*([a-zA-Z0-9_:.-]+)(\(\))? \{/ && docblock != "" {
+/^[[:space:]]*(function )?[[:space:]]*([a-zA-Z0-9_:.-]+)(\(\))? \{/ && docblock != "" {
     sub(/^function /, "")
 
     doc = doc "\n" render("h1", $1) "\n" docblock

--- a/shdoc
+++ b/shdoc
@@ -124,7 +124,7 @@ in_example {
 }
 
 /^[[:space:]]*# @see/ {
-    sub(/# @see /, "")
+    sub(/[[:space:]]*# @see /, "")
 
     $0 = render("anchor", $0)
     $0 = render("li", $0)
@@ -142,7 +142,7 @@ in_example {
 }
 
 /^[[:space:]]*(function )?[[:space:]]*([a-zA-Z0-9_:.-]+)(\(\))? \{/ && docblock != "" {
-    sub(/^function /, "")
+    sub(/^[[:space:]]*function /, "")
 
     doc = doc "\n" render("h1", $1) "\n" docblock
 


### PR DESCRIPTION
Allow spaces uses before 'function' keyword.