### PR TITLE
Add @internal tag to disable documentation generation for selected functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ _Function has no arguments._
 #### See also
 
 * [some:other:func()](#some:other:func())
+````
+
+When you want to skip documentation generation for particular function, use `@internal` tag.
+It allows you to have the same style of doc comments across the script and keep internal
+functions hidden from users.
 
 # Examples
 
@@ -93,8 +98,3 @@ See example documentation on:
 
 * [tests.sh](https://github.com/reconquest/tests.sh/blob/master/REFERENCE.md)
 * [coproc.bash](https://github.com/reconquest/coproc.bash/blob/master/REFERENCE.md)
-````
-
-When you want to skip documentation generation for particular function, use `@internal` tag.
-It allows you to have the same style of doc comments across the script and keep internal
-functions hidden from users.

--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ See example documentation on:
 
 When you want to skip documentation generation for particular function, use `@internal` tag.
 It allows you to have the same style of doc comments across the script and keep internal
-functions hidden from users
+functions hidden from users.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ some:first:func() {
 above on the stdin and will markdown output result on the stdout.
 
 Will produce following output:
-```markdown
+````markdown
 ## some:first:func()
 
 Multiline description goes here and
@@ -61,10 +61,10 @@ there
 
 #### Example
 
-`` ``` ``bash
+```bash
 some:other:func a b c
 echo 123
-`` ``` ``
+```
 
 ### Arguments
 
@@ -93,7 +93,7 @@ See example documentation on:
 
 * [tests.sh](https://github.com/reconquest/tests.sh/blob/master/REFERENCE.md)
 * [coproc.bash](https://github.com/reconquest/coproc.bash/blob/master/REFERENCE.md)
-```
+````
 
 When you want to skip documentation generation for particular function, use `@internal` tag.
 It allows you to have the same style of doc comments across the script and keep internal

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ shdoc will match comments in the following form on top of a script file:
 
 Will produce following output:
 
+```markdown
 # Title of file script
 
 Small description of the script.
+```
 
 ## Function tags
 
@@ -51,7 +53,7 @@ some:first:func() {
 above on the stdin and will markdown output result on the stdout.
 
 Will produce following output:
-
+```markdown
 ## some:first:func()
 
 Multiline description goes here and
@@ -59,10 +61,10 @@ there
 
 #### Example
 
-```bash
+`` ``` ``bash
 some:other:func a b c
 echo 123
-```
+`` ``` ``
 
 ### Arguments
 
@@ -91,3 +93,8 @@ See example documentation on:
 
 * [tests.sh](https://github.com/reconquest/tests.sh/blob/master/REFERENCE.md)
 * [coproc.bash](https://github.com/reconquest/coproc.bash/blob/master/REFERENCE.md)
+```
+
+When you want to skip documentation generation for particular function, use `@internal` tag.
+It allows you to have the same style of doc comments across the script and keep internal
+functions hidden from users

--- a/shdoc
+++ b/shdoc
@@ -1,4 +1,4 @@
-#!/usr/local/bin/gawk -f
+#!/usr/bin/awk -f
 
 BEGIN {
     if (! style) {

--- a/shdoc
+++ b/shdoc
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/local/bin/gawk -f
 
 BEGIN {
     if (! style) {
@@ -45,6 +45,10 @@ function render(type, text) {
         "g",
         text \
     )
+}
+
+/^[[:space:]]*# @internal/ {
+    is_internal = 1
 }
 
 /^[[:space:]]*# @file/ {
@@ -152,14 +156,18 @@ in_example {
 }
 
 /^[[:space:]]*(function )?[[:space:]]*([a-zA-Z0-9_:.-]+)(\(\))? \{/ && docblock != "" {
-    sub(/^[[:space:]]*function /, "")
+    if (is_internal) {
+        is_internal = 0
+    } else {
+        sub(/^[[:space:]]*function /, "")
 
-    doc = doc "\n" render("h2", $1) "\n" docblock
+        doc = doc "\n" render("h2", $1) "\n" docblock
 
-    url = $1
-    gsub(/\W/, "", url)
+        url = $1
+        gsub(/\W/, "", url)
 
-    toc = toc "\n" "* [" $1 "](#" url ")"
+        toc = toc "\n" "* [" $1 "](#" url ")"
+    }
 
     docblock = ""
 }


### PR DESCRIPTION
It is comfortable to have the same style of doc comments for all functions in .sh file.
Some of functions inside the script are intended for internal usage only, but shell has no devision on public and protected methods.

Also, to make the documentation and examples more distinguishable, I put them into 
`` ```markdown `` doc block.
