### PR TITLE
Adding OS-X install script + supporting dots

### DIFF
--- a/osx-setup.sh
+++ b/osx-setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+if [[ -d ${HOME}/.bashmatic  ]];  then
+  export bashmatic_already_installed=1
+else
+  export bashmatic_already_installed=0
+fi
+
+[[ -d ~/.bashmatic ]] || bash -c "$(curl -fsSL https://bit.ly/bashmatic-1-2-0)"
+
+source ~/.bashmatic/init.sh
+
+# remove  bashmatic after the install
+(( bashmatic_already_installed )) || trap 'rm -rf ~/.bashmatic' EXIT
+
+[[ -n $(command -v brew) ]] || brew.install
+[[ -n $(command -v gawk) ]] || {
+  info "installing GNU awk..."
+  brew.install.package gawk
+}
+
+# relink it juist in casse
+run "brew unlink gawk && brew link gawk || true"
+
+export PATH="/usr/local/bin:${PATH}"
+
+
+

--- a/shdoc
+++ b/shdoc
@@ -1,4 +1,5 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env awk -f
+# vim: ft=awk
 
 BEGIN {
     if (! style) {
@@ -165,12 +166,12 @@ in_example {
     docblock = docblock "\n\n" render("li", $0) "\n"
 }
 
-/^[ \t]*(function([ \t])+)?([a-zA-Z0-9_:-]+)([ \t]*)(\(([ \t]*)\))?[ \t]*\{/ && docblock != "" {
+/^[ \t]*(function([ \t])+)?([a-zA-Z0-9\._:-]+)([ \t]*)(\(([ \t]*)\))?[ \t]*\{/ && docblock != "" {
     if (is_internal) {
         is_internal = 0
     } else {
         func_name = gensub(\
-            /^[ \t]*(function([ \t])+)?([a-zA-Z0-9_:-]+)[ \t]*\(.*/, \
+            /^[ \t]*(function([ \t])+)?([a-zA-Z0-9\._:-]+)[ \t]*\(.*/, \
             "\\3()", \
             "g" \
         )


### PR DESCRIPTION
 * On my system default awk was throwing errors.
 * Installing gawk solved the issue.
 * My function namespaces are separated by a dot, not by colon.
 * So added a dot to the function definition regex.