### PR TITLE
Added support for indented description

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -292,7 +292,7 @@ function debug(msg) {
 }
 
 in_description {
-    if (/^[^[[:space:]]*#]|^[[:space:]]*# @[^d]|^[[:space:]]*[^#]|^[[:space:]]*$/) {
+    if (/^[^[[:space:]]*#]|^[[:space:]]*# @[^d]|^[[:space:]]*[^[[:space:]]#]|^[[:space:]]*$/) {
         debug("→ → in_description: leave")
         if (!match(description, /\n$/)) {
             description = description "\n"


### PR DESCRIPTION
In the third alternation `^[[:space:]]*[^#]` the `[^#]` character class could also capture a space so `[[:space:]]*` could capture __n__ spaces but the `[^#]` captured the last one