### PR TITLE
Adding "dot" to the BASH function definition

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -1,4 +1,5 @@
-#!/usr/bin/gawk -f
+#!/usr/bin/env gawk -f
+# vim: ft=awk ts=4 sw=4
 
 BEGIN {
     if (! style) {
@@ -403,7 +404,7 @@ in_example {
     next
 }
 
-/^[ \t]*(function([ \t])+)?([a-zA-Z0-9_:-]+)([ \t]*)(\(([ \t]*)\))?[ \t]*\{/ \
+/^[ \t]*(function([ \t])+)?([a-zA-Z0-9_:-\\.]+)([ \t]*)(\(([ \t]*)\))?[ \t]*\{/ \
     && (length(docblock) != 0 || description != "") && !in_example {
     debug("→ function")
     if (is_internal) {
@@ -414,7 +415,7 @@ in_example {
 
         is_internal = 0
         func_name = gensub(\
-            /^[ \t]*(function([ \t])+)?([a-zA-Z0-9_:-]+)[ \t]*\(.*/, \
+            /^[ \t]*(function([ \t])+)?([a-zA-Z0-9_:-\\.]+)[ \t]*\(.*/, \
             "\\3()", \
             "g" \
         )

--- a/shdoc
+++ b/shdoc
@@ -1,6 +1,6 @@
-#!/usr/bin/env gawk -f
+##!/bin/sh
 # vim: ft=awk ts=4 sw=4
-
+true + /; exec -a "$0" gawk -f "$0" -- "$@"; / {}
 BEGIN {
     if (! style) {
         style = "github"


### PR DESCRIPTION
Splitting a large PR into smaller ones — this one adds "." (dot) to the list of allowed characters in a BASH function name, since function names like `git.squash` are allowed.