### PR TITLE
Implement a `@set` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ say-hello-world() {
 }
 ```
 
+### `@set`
+
+A description of a global variable that is set while calling the function.
+Can be specified multiple times to describe any number of variables
+
+**Example**
+# @description Sets hello to the variable REPLY
+# @set REPLY string Greeting message.
+```bash
+set-hello() {
+    ...
+}
+```
+
 ### `@exitcode`
 
 Describes an expected exitcode of the function.

--- a/shdoc
+++ b/shdoc
@@ -29,6 +29,9 @@ BEGIN {
     styles["github", "arg@", "from"] = "^\\$@ (\\S+)"
     styles["github", "arg@", "to"] = "**...** (\\1):"
 
+    styles["github", "set", "from"] = "^(\\S+) (\\S+)"
+    styles["github", "set", "to"] = "**\\1** (\\2):"
+
     styles["github", "li", "from"] = ".*"
     styles["github", "li", "to"] = "* &"
 
@@ -213,6 +216,19 @@ function render_docblock(func_name, description, docblock) {
         push(lines, render("i", "Function has no arguments.") "\n")
     }
 
+    if ("set" in docblock) {
+        push(lines, render("h4", "Variables set") "\n")
+        for (i in docblock["set"]) {
+            item = docblock["set"][i]
+            item = render("set", item)
+            item = render("li", item)
+            if (i == length(docblock["set"])) {
+                item = item "\n"
+            }
+            push(lines, item)
+        }
+    }
+
     if ("exitcode" in docblock) {
         push(lines, render("h4", "Exit codes") "\n")
         for (i in docblock["exitcode"]) {
@@ -362,6 +378,15 @@ in_example {
 /^[[:space:]]*# @noargs/ {
     debug("→ @noargs")
     docblock["noargs"] = 1
+
+    next
+}
+
+/^[[:space:]]*# @set/ {
+    debug("→ @set")
+    sub(/^[[:space:]]*# @set /, "")
+
+    docblock_push("set", $0)
 
     next
 }

--- a/tests/testcases/@set.test.sh
+++ b/tests/testcases/@set.test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+tests:put input <<EOF
+# @name Project Name
+# @brief Brief
+# @description a
+
+# @description func b
+# @set B int Error code if an erorr occured
+# @set C array Some array thing
+b() {
+}
+
+EOF
+
+tests:put expected <<EOF
+# Project Name
+
+Brief
+
+## Overview
+
+a
+
+## Index
+
+* [b()](#b)
+
+### b()
+
+func b
+
+#### Variables set
+
+* **B** (int): Error code if an erorr occured
+* **C** (array): Some array thing
+EOF
+
+assert

--- a/tests/testcases/function-tags.test.sh
+++ b/tests/testcases/function-tags.test.sh
@@ -13,6 +13,8 @@ tests:put input <<EOF
 #
 # @noargs
 #
+# @set A string Variable was set
+#
 # @exitcode 0  If successfull.
 # @exitcode >0 On failure
 # @exitcode 5  On some error.
@@ -47,6 +49,10 @@ echo 123
 * **...** (any): Rest of arguments.
 
 _Function has no arguments._
+
+#### Variables set
+
+* **A** (string): Variable was set
 
 #### Exit codes
 


### PR DESCRIPTION
Hai ^_^

This implements the `@set` tag as proposed in #38. It seemed apt to format its resulting markdown similar to `@arg`

Would there be any suggestions for an alternative to its `Variables set` heading? I'm not sure it sounds right

Of course, lemmie know if there is anything that needs to be changed

If merged, closes #38 (and I suppose closes #34?)