### PR TITLE
Allow @see to pass markdown links as is. Close #52.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,11 +266,12 @@ say-hello-world() {
 
 ### `@see`
 
-Create a link on the given function in the See Also section.
+Create a link on the given function in the "See Also" section.
 
 **Example**
 ```bash
 # @see say-hello
+# @see text with [markdown link](./other-file#other-function)
 say-hello-world() {
     ...
 }

--- a/examples/readme-example.md
+++ b/examples/readme-example.md
@@ -12,9 +12,9 @@ The project solves lots of problems:
 
 ## Index
 
-* [say-hello()](#say-hello)
+* [say-hello](#say-hello)
 
-### say-hello()
+### say-hello
 
 My super function.
 Not thread-safe.
@@ -37,3 +37,5 @@ echo "test: $(say-hello World)"
 #### See also
 
 * [validate()](#validate)
+* Documentation generated using [shdoc](https://github.com/reconquest/shdoc).
+

--- a/examples/readme-example.sh
+++ b/examples/readme-example.sh
@@ -20,6 +20,7 @@
 # @exitcode 1 If an empty string passed.
 #
 # @see validate()
+# @see Documentation generated using [shdoc](https://github.com/reconquest/shdoc).
 say-hello() {
     if [[ ! "$1" ]]; then
         return 1;

--- a/shdoc
+++ b/shdoc
@@ -62,6 +62,10 @@ function render(type, text) {
 }
 
 function render_toc_link(title) {
+    # If title contains a markdown link, return as is.
+    if (title ~ /\[[^\]]*\]([^)]*)/) {
+        return title
+    }
     url = title
     if (style == "github") {
       # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb#L44-L45

--- a/shdoc
+++ b/shdoc
@@ -61,20 +61,42 @@ function render(type, text) {
     )
 }
 
-function render_toc_link(title) {
-    # If title contains a markdown link, return as is.
-    if (title ~ /\[[^\]]*\]([^)]*)/) {
-        return title
+function render_toc_link(text) {
+    # URL processing
+    # @see Regexp sourced from https://stackoverflow.com/questions/3183444/check-for-valid-link-url
+
+    # If text start by '/', './' or '../', assume it is a relative link.
+    if (text ~ /^\.{0,2}\//) {
+        return "[" text "](" text ")"
     }
-    url = title
+
+    # If text contains URLs, but not a markdown links, transform the URLs in markdown links.
+    # Assume a URL is in a markdown link if it follow '](' string.
+    if ("  " text " " ~ /[^\]]([^a-z(]|\()[a-z]+:\/\/[-[:alnum:]+&@#\/%?=~_|!:,.;]*[-[:alnum:]\+&@#\/%=~_|]/) {
+        # Add space at the end of text to allow for easy detection of URLs.
+        text = "  " text " "
+        # Enclose URLs in markdown links.
+        text = gensub(/([^\]]([^a-z(]|\())([a-z]+:\/\/[-[:alnum:]+&@#\/%?=~_|!:,.;]*[-[:alnum:]\+&@#\/%=~_|])/, "\\1[\\3](\\3)", "g", text)
+        # Trim spaces added to ease unenclosed URL regex creation.
+        gsub(/^[[:blank:]]*/, "", text)
+        gsub(/[[:blank:]]*$/, "", text)
+        return text
+    }
+
+    # If title contains a markdown link, return as is.
+    if (text ~ /\[[^\]]*\]([^)]*)/) {
+        return text
+    }
+
+    url = text
     if (style == "github") {
-      # https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb#L44-L45
+      # @see https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb#L44-L45
       url = tolower(url)
       gsub(/[^[:alnum:] _-]/, "", url)
       gsub(/ /, "-", url)
     }
 
-    return "[" title "](#" url ")"
+    return "[" text "](#" url ")"
 }
 
 function render_toc_item(title) {

--- a/tests/testcases/@see.test.sh
+++ b/tests/testcases/@see.test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# @file test/testcases/@see.test.sh
+# @author Pierre-Yves Landuré < contact at biapy dot fr >
+# @brief Test cases for @see keyword.
+# @description
+#   Test these @see comportements:
+#   - one string (i.e. function name.)
+#   - two strings
+#   - function name containing ':'.
+#   - string starting by '.'
+#   - one relative path starting with './'.
+#   - one relative path starting with '../'.
+#   - one absolute path.
+#   - string that is not a relative path (starting with '.../').
+#   - a https URL.
+#   - a file URL.
+#   - a URL in a text.
+#   - two URL in a text.
+#   - a markdown link.
+#   - a text containing a markdown link.
+#   - a text containing a markdown link and a URL.
+tests:put input <<EOF
+# @name shdoc @see tests
+# @brief Test @see functionnality.
+# @description Tests for shdoc processing of @see keyword.
+
+# @description test-see dummy function.
+# @see test-failing-see
+# @see test-working-see test-failing-see
+# @see some:other:func()
+# @see .string-starting-by-dot
+# @see ./some/relative/path
+# @see ../some/other/relative/path
+# @see /some/absolute/path
+# @see .../some/strange/string
+# @see https://github.com/reconquest/shdoc
+# @see file://var/log/syslog
+# @see shdoc: https://github.com/reconquest/shdoc
+# @see shdoc (https://github.com/reconquest/shdoc) and https://github.com/reconquest/import.bash
+# @see [shdoc](https://github.com/reconquest/shdoc)
+# @see Shell documation generator [shdoc](https://github.com/reconquest/shdoc).
+# @see Shell documation generator [shdoc](https://github.com/reconquest/shdoc) (and https://github.com/reconquest/import.bash).
+test-working-see() {
+}
+
+EOF
+
+tests:put expected <<EOF
+# shdoc @see tests
+
+Test @see functionnality.
+
+## Overview
+
+Tests for shdoc processing of @see keyword.
+
+## Index
+
+* [test-working-see](#test-working-see)
+
+### test-working-see
+
+test-see dummy function.
+
+#### See also
+
+* [test-failing-see](#test-failing-see)
+* [test-working-see test-failing-see](#test-working-see-test-failing-see)
+* [some:other:func()](#someotherfunc)
+* [.string-starting-by-dot](#string-starting-by-dot)
+* [./some/relative/path](./some/relative/path)
+* [../some/other/relative/path](../some/other/relative/path)
+* [/some/absolute/path](/some/absolute/path)
+* [.../some/strange/string](#somestrangestring)
+* [https://github.com/reconquest/shdoc](https://github.com/reconquest/shdoc)
+* [file://var/log/syslog](file://var/log/syslog)
+* shdoc: [https://github.com/reconquest/shdoc](https://github.com/reconquest/shdoc)
+* shdoc ([https://github.com/reconquest/shdoc](https://github.com/reconquest/shdoc)) and [https://github.com/reconquest/import.bash](https://github.com/reconquest/import.bash)
+* [shdoc](https://github.com/reconquest/shdoc)
+* Shell documation generator [shdoc](https://github.com/reconquest/shdoc).
+* Shell documation generator [shdoc](https://github.com/reconquest/shdoc) (and [https://github.com/reconquest/import.bash](https://github.com/reconquest/import.bash)).
+EOF
+
+assert

--- a/tests/testcases/function-tags.test.sh
+++ b/tests/testcases/function-tags.test.sh
@@ -23,6 +23,7 @@ tests:put input <<EOF
 # @stdout Path to something.
 #
 # @see some:other:func()
+# @see Shell documation generator [shdoc](https://github.com/reconquest/shdoc).
 some:first:func() {
 EOF
 
@@ -71,6 +72,7 @@ _Function has no arguments._
 #### See also
 
 * [some:other:func()](#someotherfunc)
+* Shell documation generator [shdoc](https://github.com/reconquest/shdoc).
 EOF
 
 assert


### PR DESCRIPTION
This modification detect is @see contains a markdown link (`[]()`) and pass the content as is if it is the case.

This close #52 and allow to use HTTP(S) URLs in @see.

I've updated the readme, the example file and unit tests.