### PR TITLE
Stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,19 @@ say-hello-world() {
 }
 ```
 
+### `@stderr`
+
+An expected output of the function call on `/dev/stderr`.
+
+**Example**
+```bash
+# @description Says 'hello world'.
+# @stderr A error message when world is not available.
+say-hello-world() {
+    ...
+}
+```
+
 ### `@see`
 
 Create a link on the given function in the See Also section.

--- a/examples/readme-example.md
+++ b/examples/readme-example.md
@@ -12,9 +12,9 @@ The project solves lots of problems:
 
 ## Index
 
-* [say-hello()](#say-hello)
+* [say-hello](#say-hello)
 
-### say-hello()
+### say-hello
 
 My super function.
 Not thread-safe.
@@ -34,6 +34,15 @@ echo "test: $(say-hello World)"
 * **0**: If successful.
 * **1**: If an empty string passed.
 
+#### Output on stdout
+
+* Output 'Hello $1'.
+
+#### Output on stderr
+
+* Output 'Oups !' on error.
+
 #### See also
 
 * [validate()](#validate)
+

--- a/examples/readme-example.md
+++ b/examples/readme-example.md
@@ -37,10 +37,12 @@ echo "test: $(say-hello World)"
 #### Output on stdout
 
 * Output 'Hello $1'.
+  It hopes you say Hello back.
 
 #### Output on stderr
 
 * Output 'Oups !' on error.
+  It did it again.
 
 #### See also
 

--- a/examples/readme-example.sh
+++ b/examples/readme-example.sh
@@ -17,7 +17,9 @@
 # @arg $1 string A value to print
 #
 # @stdout Output 'Hello $1'.
+#   It hopes you say Hello back.
 # @stderr Output 'Oups !' on error.
+#   It did it again.
 #
 # @exitcode 0 If successful.
 # @exitcode 1 If an empty string passed.

--- a/examples/readme-example.sh
+++ b/examples/readme-example.sh
@@ -16,12 +16,16 @@
 #
 # @arg $1 string A value to print
 #
+# @stdout Output 'Hello $1'.
+# @stderr Output 'Oups !' on error.
+#
 # @exitcode 0 If successful.
 # @exitcode 1 If an empty string passed.
 #
 # @see validate()
 say-hello() {
     if [[ ! "$1" ]]; then
+        echo "Oups !" >&2
         return 1;
     fi
 

--- a/shdoc
+++ b/shdoc
@@ -44,6 +44,8 @@ BEGIN {
     styles["github", "exitcode", "from"] = "([>!]?[0-9]{1,3}) (.*)"
     styles["github", "exitcode", "to"] = "**\\1**: \\2"
 
+    stderr_section_flag = 0
+
     debug_enable = ENVIRON["SHDOC_DEBUG"] == "1"
     debug_fd = ENVIRON["SHDOC_DEBUG_FD"]
     if (!debug_fd) {
@@ -186,6 +188,43 @@ function docblock_push(key, value) {
     docblock[key][length(docblock[key])+1] = value
 }
 
+
+# @description Append a text to the last item of a docblock.
+#
+# @param docblock_name  Name of the modified docblock.
+# @param text           Appended text.
+#
+# @set docblock[docblock_name] docblock with text appended to last item.
+function docblock_append(docblock_name, text) {
+    # Detect last docblock item index.
+    last_item_index = length(docblock[docblock_name])
+    # Append text to last docblock item.
+    docblock[docblock_name][last_item_index] = docblock[docblock_name][last_item_index] text
+}
+
+# @description Render a docblock as an unordered list.
+#
+# @param dockblock      Dockblock array.
+# @param dockblock_name Name of the rendered docblock.
+# @param title          Title of the rendered section.
+#
+# @stdout A unordered list of the dockblock entries.
+function render_docblock_list(docblock, docblock_name, title) {
+    push(lines, render("h4", title) "\n")
+    # Initialize list item.
+    item = ""
+    # For each dockblock line.
+    for (i in docblock[docblock_name]) {
+        # Ident additionnal lines to add them to the markdown list item.
+        gsub(/\n/, "\n  ", docblock[docblock_name][i])
+        item = render("li", docblock[docblock_name][i])
+        push(lines, item)
+    }
+
+    # Add empty line to signal end of list in markdown.
+    push(lines, "")
+}
+
 function render_docblock(func_name, description, docblock) {
     debug("→ render_docblock")
     debug("→ → func_name: [" func_name "]")
@@ -259,25 +298,15 @@ function render_docblock(func_name, description, docblock) {
     }
 
     if ("stdin" in docblock) {
-        push(lines, render("h4", "Input on stdin") "\n")
-        for (i in docblock["stdin"]) {
-            item = render("li", docblock["stdin"][i])
-            if (i == length(docblock["stdin"])) {
-                item = item "\n"
-            }
-            push(lines, item)
-        }
+        render_docblock_list(docblock, "stdin", "Input on stdin")
     }
 
     if ("stdout" in docblock) {
-        push(lines, render("h4", "Output on stdout") "\n")
-        for (i in docblock["stdout"]) {
-            item = render("li", docblock["stdout"][i])
-            if (i == length(docblock["stdout"])) {
-                item = item "\n"
-            }
-            push(lines, item)
-        }
+        render_docblock_list(docblock, "stdout", "Output on stdout")
+    }
+
+    if ("stderr" in docblock) {
+        render_docblock_list(docblock, "stderr", "Output on stderr")
     }
 
     if ("see" in docblock) {
@@ -435,23 +464,49 @@ in_example {
     next
 }
 
-/^[[:space:]]*# @stdin/ {
-    debug("→ @stdin")
+# Previous line added a new docblock item.
+# Check if current line has the needed indentation
+# for it to be a multiple lines docblock item.
+multiple_line_docblock_name {
+    # Check if current line indentation does match the previous line docblock item.
+    if ($0 ~ multiple_line_identation_regex ) {
+        debug("→ @" multiple_line_docblock_name)
+        
+        # Current line has the same indentation as the stderr section.
+    
+        # Remove indentation and trailing spaces.
+        sub(/^[[:space:]]*#[[:space:]]+/, "")
+        sub(/[[:space:]]+$/, "")
 
-    sub(/^[[:space:]]*# @stdin /, "")
+        # Push matched message to corresponding docblock.
+        docblock_append(multiple_line_docblock_name, "\n" $0)
 
-    docblock_push("stdin", $0)
-
-    next
+        # Stop processing current line, and process next line.
+        next
+    } else {
+        # End previous line docblock item.
+        multiple_line_docblock_name = ""
+    }
 }
 
-/^[[:space:]]*# @stdout/ {
-    debug("→ @stdout")
+# Process similarly @stdin, @stdout and @stderr entries.
+# Allow for multiple lines entries.
+match($0, /^([[:blank:]]*#[[:blank:]]+)@(stdin|stdout|stderr)[[:blank:]]+(.*[^[:blank:]])[[:blank:]]*$/, contents) {
+    # Fetch matched values.
+    indentation = contents[1]
+    docblock_name = contents[2]
+    text = contents[3]
 
-    sub(/^[[:space:]]*# @stdout /, "")
+    debug("→ @" docblock_name)
 
-    docblock_push("stdout", $0)
+    # Push matched message to corresponding docblock.
+    docblock_push(docblock_name, text)
 
+    # Signal the start of a multiple line section.
+    multiple_line_docblock_name = docblock_name
+    multiple_line_identation_regex = "^" indentation "[[:blank:]]+[^[:blank:]].*$"
+
+    # Stop processing current line, and process next line.
     next
 }
 

--- a/tests/testcases/@stderr.test.sh
+++ b/tests/testcases/@stderr.test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# @file test/testcases/@stderr.test.sh
+# @author Pierre-Yves Landuré < contact at biapy dot fr >
+# @brief Test cases for @stderr keyword.
+# @description
+#   Test these @stderr comportements:
+#   - one string (i.e. function name.)
+#   - two strings
+#   - function name containing ':'.
+#   - string starting by '.'
+#   - one relative path starting with './'.
+#   - one relative path starting with '../'.
+#   - one absolute path.
+#   - string that is not a relative path (starting with '.../').
+#   - a https URL.
+#   - a file URL.
+#   - a URL in a text.
+#   - two URL in a text.
+#   - a markdown link.
+#   - a text containing a markdown link.
+#   - a text containing a markdown link and a URL.
+
+tests:put input <<EOF
+# @name shdoc @stderr tests
+# @brief Test @stderr functionnality.
+# @description Tests for shdoc processing of @stderr keyword.
+# @description test-stderr dummy function.
+# @stderr Standard stderr message.
+# @stdout section should appear before stderr section.
+# @see see-also-after-stderr-section
+# @stderr Stderr message with [markdown link](https://github.com/reconquest/shdoc).
+# @stderr       Indented with spaces stderr message.
+# @stderr Multiple lines
+#   stderr message.
+# line outside of multiple lines stderr message (ignored).
+# @stderr Failed multiple lines
+    # std err message.
+    #   @stderr Idented multiple lines
+    #       stderr message
+# @stderr Stderr message with trailing spaces.      
+test-stderr() {
+}
+EOF
+
+tests:put expected <<EOF
+# shdoc @stderr tests
+
+Test @stderr functionnality.
+
+## Overview
+
+Tests for shdoc processing of @stderr keyword.
+## Index
+
+* [test-stderr](#test-stderr)
+
+### test-stderr
+
+test-stderr dummy function.
+
+#### Output on stdout
+
+* section should appear before stderr section.
+
+#### Output on stderr
+
+* Standard stderr message.
+* Stderr message with [markdown link](https://github.com/reconquest/shdoc).
+* Indented with spaces stderr message.
+* Multiple lines
+  stderr message.
+* Failed multiple lines
+* Idented multiple lines
+  stderr message
+* Stderr message with trailing spaces.
+
+#### See also
+
+* [see-also-after-stderr-section](#see-also-after-stderr-section)
+
+EOF
+
+assert

--- a/tests/testcases/@stdin.test.sh
+++ b/tests/testcases/@stdin.test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# @file test/testcases/@stdin.test.sh
+# @author Pierre-Yves Landuré < contact at biapy dot fr >
+# @brief Test cases for @stdin keyword.
+# @description
+#   Test these @stdin comportements:
+#   - simple one line message.
+#   - one line message with indentation and trailing spaces.
+#   - indented two lines message.
+#   - three lines message with trailing spaces.
+#   - appears between @stdin and @stderr sections.
+
+tests:put input <<EOF
+# @name shdoc @stdin tests
+# @brief Test @stdin functionnality.
+# @description Tests for shdoc processing of @stdin keyword.
+# @description test-stdin dummy function.
+# @see see-also-after-stderr-section
+# @stdin simple one line message.
+# @stdout Stdout section appears after stdin section.
+# @stdin         one line message with indentation and trailing spaces.    
+    #   @stdin   indented two lines message
+    #         to test how indentation is trimmed.
+    #   Message without sufficient indentation (ignored).
+# @stderr Error output description.
+# @stdin tree lines messages    
+#     with trailing spaces    
+#   and random indentation.
+# @exitcode 0 Exit code section appears before stdin section.
+test-stdin() {
+}
+EOF
+
+tests:put expected <<EOF
+# shdoc @stdin tests
+
+Test @stdin functionnality.
+
+## Overview
+
+Tests for shdoc processing of @stdin keyword.
+## Index
+
+* [test-stdin](#test-stdin)
+
+### test-stdin
+
+test-stdin dummy function.
+
+#### Exit codes
+
+* **0**: Exit code section appears before stdin section.
+
+#### Input on stdin
+
+* simple one line message.
+* one line message with indentation and trailing spaces.
+* indented two lines message
+  to test how indentation is trimmed.
+* tree lines messages
+  with trailing spaces
+  and random indentation.
+
+#### Output on stdout
+
+* Stdout section appears after stdin section.
+
+#### Output on stderr
+
+* Error output description.
+
+#### See also
+
+* [see-also-after-stderr-section](#see-also-after-stderr-section)
+
+EOF
+
+assert

--- a/tests/testcases/@stdout.test.sh
+++ b/tests/testcases/@stdout.test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# @file test/testcases/@stdout.test.sh
+# @author Pierre-Yves Landuré < contact at biapy dot fr >
+# @brief Test cases for @stdout keyword.
+# @description
+#   Test these @stdout comportements:
+#   - simple one line message.
+#   - one line message with indentation and trailing spaces.
+#   - indented two lines message.
+#   - three lines message with trailing spaces.
+#   - appears between @stdin and @stderr sections.
+
+tests:put input <<EOF
+# @name shdoc @stdout tests
+# @brief Test @stdout functionnality.
+# @description Tests for shdoc processing of @stdout keyword.
+# @description test-stdout dummy function.
+# @see see-also-after-stderr-section
+# @stdout simple one line message.
+# @stdout         one line message with indentation and trailing spaces.    
+    #   @stdout   indented two lines message
+    #         to test how indentation is trimmed.
+    #   Message without sufficient indentation (ignored).
+# @stderr Error output description.
+# @stdout tree lines messages    
+#     with trailing spaces    
+#   and random indentation.  
+# @stdin Input stream description.
+test-stdout() {
+}
+EOF
+
+tests:put expected <<EOF
+# shdoc @stdout tests
+
+Test @stdout functionnality.
+
+## Overview
+
+Tests for shdoc processing of @stdout keyword.
+## Index
+
+* [test-stdout](#test-stdout)
+
+### test-stdout
+
+test-stdout dummy function.
+
+#### Input on stdin
+
+* Input stream description.
+
+#### Output on stdout
+
+* simple one line message.
+* one line message with indentation and trailing spaces.
+* indented two lines message
+  to test how indentation is trimmed.
+* tree lines messages
+  with trailing spaces
+  and random indentation.
+
+#### Output on stderr
+
+* Error output description.
+
+#### See also
+
+* [see-also-after-stderr-section](#see-also-after-stderr-section)
+
+EOF
+
+assert

--- a/tests/testcases/function-tags.test.sh
+++ b/tests/testcases/function-tags.test.sh
@@ -21,6 +21,7 @@ tests:put input <<EOF
 #
 # @stdin Path to something.
 # @stdout Path to something.
+# @stderr Stderr description.
 #
 # @see some:other:func()
 some:first:func() {
@@ -67,6 +68,10 @@ _Function has no arguments._
 #### Output on stdout
 
 * Path to something.
+
+#### Output on stderr
+
+* Stderr description.
 
 #### See also
 


### PR DESCRIPTION
This pull request fix #57.

I've refactored the code to use the same logic for @stdin, @stdout and @stderr.
I've added complexity to allow for multiple lines @std* messages to be added base on indentation.
The messages are trimmed and indentation is lost to return to the same alignment.
I've added unit tests specific to the changes, but no previous unit tests were failed.

This silently fix an issue where @stdoutsomething was seen as @stdout (same apply for @stdinsomething).