### PR TITLE
fix: Use the `#!/usr/bin/env bash` shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ shdoc < lib.sh > doc.md
 _Source_ [examples/readme-example.sh](examples/readme-example.sh)<br />
 _Output_: [examples/readme-example.md](examples/readme-example.md)<br/><br/>
 ~~~bash
-#!/bin/bash
+#!/usr/bin/env bash
 # @file libexample
 # @brief A library that solves some common problems.
 # @description
@@ -153,7 +153,7 @@ file.
 **Example**
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # @name MyLibrary
 ```
 
@@ -167,7 +167,7 @@ A brief line about the project. Can be specified once in the beginning of the fi
 
 **Example**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # @brief A library to solve a few problems.
 ```
 
@@ -180,7 +180,7 @@ A multiline description of the project/section/function.
 
 **Example**
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # @description A long description of the library.
 # Second line of the project description.
 

--- a/examples/readme-example.sh
+++ b/examples/readme-example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file libexample
 # @brief A library that solves some common problems.
 # @description

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/tests/testcases/@function-declaration.test.sh
+++ b/tests/testcases/@function-declaration.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
 # @name Project Name

--- a/tests/testcases/@name-and-@description.test.sh
+++ b/tests/testcases/@name-and-@description.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
 # @name Project Name

--- a/tests/testcases/@option.test.sh
+++ b/tests/testcases/@option.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file test/testcases/@optional-arguments.test.sh
 # @author Pierre-Yves Landuré < contact at biapy dot fr >
 # @brief Test cases for @option keyword with options.

--- a/tests/testcases/@see.test.sh
+++ b/tests/testcases/@see.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file test/testcases/@see.test.sh
 # @author Pierre-Yves Landuré < contact at biapy dot fr >
 # @brief Test cases for @see keyword.

--- a/tests/testcases/@set.test.sh
+++ b/tests/testcases/@set.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
 # @name Project Name

--- a/tests/testcases/@stderr.test.sh
+++ b/tests/testcases/@stderr.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file test/testcases/@stderr.test.sh
 # @author Pierre-Yves Landuré < contact at biapy dot fr >
 # @brief Test cases for @stderr keyword.

--- a/tests/testcases/@stdin.test.sh
+++ b/tests/testcases/@stdin.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file test/testcases/@stdin.test.sh
 # @author Pierre-Yves Landuré < contact at biapy dot fr >
 # @brief Test cases for @stdin keyword.

--- a/tests/testcases/@stdout.test.sh
+++ b/tests/testcases/@stdout.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file test/testcases/@stdout.test.sh
 # @author Pierre-Yves Landuré < contact at biapy dot fr >
 # @brief Test cases for @stdout keyword.

--- a/tests/testcases/function-in-@example.test.sh
+++ b/tests/testcases/function-in-@example.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
 # @description Same, as \`tests:eval\`, but writes stdout into given variable and

--- a/tests/testcases/function-tags.test.sh
+++ b/tests/testcases/function-tags.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
 # @description Multiline description goes here and

--- a/tests/testcases/global-tags.test.sh
+++ b/tests/testcases/global-tags.test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # @file Title of file script
 # @brief Small description of the script.

--- a/tests/testcases/issue-12-no-space-in-function-declaration.test.sh
+++ b/tests/testcases/issue-12-no-space-in-function-declaration.test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 # @description a desc for fn1
 fn1() {

--- a/tests/testcases/issue-25-missing-trailing-newline-in-see-also.test.sh
+++ b/tests/testcases/issue-25-missing-trailing-newline-in-see-also.test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 # @description a desc for fn1
 # @see fn2()

--- a/tests/testcases/issue-4-whitespace-in-function-declaration.test.sh
+++ b/tests/testcases/issue-4-whitespace-in-function-declaration.test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 # @arg \$1 string fn var.
 # @stdout result of fn

--- a/tests/testcases/issue-56-function-opening-bracket-on-separate-line.test.sh
+++ b/tests/testcases/issue-56-function-opening-bracket-on-separate-line.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
 #!/sbin/sh

--- a/tests/testcases/numbered-arguments.test.sh
+++ b/tests/testcases/numbered-arguments.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # @file test/testcases/@numbered-arguments.test.sh
 # @author Pierre-Yves Landuré < contact at biapy dot fr >
 # @brief Test cases for @arg keyword.

--- a/tests/testcases/table-of-contents.test.sh
+++ b/tests/testcases/table-of-contents.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tests:put input <<EOF
 # @description example function 1


### PR DESCRIPTION
`/bin/bash` doesn't always exist on POSIX-y systems, like NixOS and some BSDs (when Bash is installed).