### PR TITLE
chore: Add basic EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/shdoc
+++ b/shdoc
@@ -403,23 +403,23 @@ function render_docblock_list(docblock, docblock_name, title) {
 #   long_option_regex = "--[[:alnum:]][[:alnum:]-]*((=|[[:blank:]]+)<[^>]+>)?"
 #   pipe_separator_regex = "([[:blank:]]*\\|?[[:blank:]]+)"
 #   description_regex = "([^[:blank:]|<-].*)?"
-#   
+#
 #   # Build regex matching all options
 #   short_or_long_option_regex = sprintf("(%s|%s)", short_option_regex, long_option_regex)
-# 
+#
 #   # Build regex matching multiple options separated by spaces or pipe.
 #   all_options_regex = sprintf("(%s%s)+", short_or_long_option_regex, pipe_separator_regex)
-# 
+#
 #   # Build final regex.
 #   optional_arg_regex = sprintf("^(%s)%s$", all_options_regex, description_regex)
 #   ```
-# 
+#
 #   Final regex with non-matching groups (unsupported by gawk).
-# 
+#
 #   `^((?:(?:-[[:alnum:]](?:[[:blank:]]*<[^>]+>)?|--[[:alnum:]][[:alnum:]-]*(?:(?:=|[[:blank:]]+)<[^>]+>)?)(?:[[:blank:]]*\|?[[:blank:]]+))+)([^[:blank:]|<-].*)?$`
 #
 # @param text   The text to process as an @option entry.
-# 
+#
 # @set dockblock["option"] A docblock for correctly formated options.
 # @set dockblock["option-bad"] A docblock for badly formated options.
 function process_at_option(text) {
@@ -708,7 +708,7 @@ in_example {
 # Select @arg lines with content.
 /^[[:blank:]]*#[[:blank:]]+@arg[[:blank:]]+[^[:blank:]]/ {
     debug("→ @arg")
-    
+
     arg_text = $0
 
     # Remove '# @arg ' tag.
@@ -790,9 +790,9 @@ multiple_line_docblock_name {
     # Check if current line indentation does match the previous line docblock item.
     if ($0 ~ multiple_line_identation_regex ) {
         debug("→ @" multiple_line_docblock_name " - new line")
-        
+
         # Current line has the same indentation as the stderr section.
-    
+
         # Remove indentation and trailing spaces.
         sub(/^[[:space:]]*#[[:space:]]+/, "")
         sub(/[[:space:]]+$/, "")
@@ -899,18 +899,18 @@ END {
         print render("h1", file_title)
 
         if (file_brief != "") {
-            print file_brief "\n" 
+            print file_brief "\n"
         }
 
         if (file_description != "") {
             print render("h2", "Overview")
-            print file_description "\n" 
+            print file_description "\n"
         }
     }
 
     if (toc != "") {
         print render("h2", "Index")
-        print toc "\n" 
+        print toc "\n"
     }
 
     print doc


### PR DESCRIPTION
It is difficult (annoying) to edit the `shdoc` file because there are trailing whitespace characters (a special option must be selected while saving, to save without formatting).

This fixes that by:

- Removing the trailing whitespace characters so others don't run into the issue
- Creating an `.editorconfig`, and configuring it to trim trailing whitespace characters so this doesn't happen in the future
  - I intentionally left `indent_style` and `indent_size` unconfigured 