### PR TITLE
Fix underscores in github markdown links

### DIFF
--- a/shdoc
+++ b/shdoc
@@ -178,7 +178,6 @@ function render_toc_link(text) {
       # @see https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb#L44-L45
       url = tolower(url)
       gsub(/[^[:alnum:] _-]/, "", url)
-      gsub(/_/, "", url)
       gsub(/ /, "-", url)
     }
 


### PR DESCRIPTION
Use the actual header name in links (do not remove underscores). This fixes broken index links in GitHub Markdown format.