### PR TITLE
Add Fedora & EPEL information

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,14 @@ $ shdoc --version
 
 Arch Linux users can install shdoc using package in AUR: [shdoc-git](https://aur.archlinux.org/packages/shdoc-git)
 
+### Fedora & EPEL
+
+Fedora and EPEL releases ship the `shdoc` package:
+
+```bash
+dnf install shdoc
+```
+
 ### Using Git
 
 NOTE: shdoc requires gawk: `apt-get install gawk`


### PR DESCRIPTION
`shdoc` has been available since Fedora 38: https://repology.org/project/shdoc/versions

Updates for 1.4 (not 1.14, check the typo in the release) will land in a few days: https://bodhi.fedoraproject.org/updates/?search=shdoc

